### PR TITLE
Removing state pollution in `init_ExpStock.__next__()`

### DIFF
--- a/expstock/test_expstock.py
+++ b/expstock/test_expstock.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+import copy
 from datetime import datetime
 import mock
 import os
@@ -65,7 +66,7 @@ def test__get_git_info(init_ExpStock):
     assert git_diff == expect_git_diff
 
 def test_append_param(init_ExpStock):
-    e = init_ExpStock.__next__()
+    e = copy.deepcopy(init_ExpStock.__next__())
     test_param1 = 12345
     test_param2 = 'test_param'
     e.append_param(test_param1=test_param1, test_param2=test_param2)


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_append_param` by removing state pollution in `init_ExpStock.__next__()` by making a deep copy.

The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest --count=2 expstock/test_expstock.py::test_append_param`:

```
    def test_append_param(init_ExpStock):
        e = init_ExpStock.__next__()
        test_param1 = 12345
        test_param2 = 'test_param'
        e.append_param(test_param1=test_param1, test_param2=test_param2)
        e.params.sort()
>       assert e.params == [('test_param1', 12345), ('test_param2', 'test_param')]
E       AssertionError: assert [('test_param1', 12345),\n ('test_param1', 12345),\n ('test_param2', 'test_param'),\n ('test_param2', 'test_param')] == [('test_param1', 12345), ('test_param2', 'test_param')]
```

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
